### PR TITLE
quicker access to clitogui function, along with a shortcut 'on' + doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Python package to generate a GUI from argparse CLI.
 
 Just add the decorator to the main or parser function:
 
-    from clitogui import clitogui
+    import clitogui
 
-    @clitogui
+    @clitogui.on
     def create_parser() -> argparse.ArgumentParser:
         """
         Function to define the parser

--- a/clitogui/__init__.py
+++ b/clitogui/__init__.py
@@ -1,1 +1,2 @@
 __version__ = '0.0.2.dev0'
+from .clitogui import clitogui, on

--- a/clitogui/clitogui.py
+++ b/clitogui/clitogui.py
@@ -63,3 +63,6 @@ def clitogui(parser_function):
             return argparse_to_gui(parser_function)
         else:
             raise TypeError("Not supported parser")
+
+# shortcut
+on = clitogui


### PR DESCRIPTION
Instead of:


    from clitogui import clitogui

    @clitogui
    def create_parser() -> argparse.ArgumentParser:

We got:

    import clitogui

    @clitogui.on
    def create_parser() -> argparse.ArgumentParser:
